### PR TITLE
Improve operation summaries and add field descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [3.0.0] - 2026-06-26
+
+### Changed
+- Updated the default service URL to include the `/companies` path segment
+  (`https://api.hubapi.com/crm/v3/objects/companies`). Resource paths no longer carry
+  the `/companies` prefix (e.g. `companies/batch/read` → `batch/read`). This is a
+  breaking change — existing callers must update resource call sites and any custom
+  `serviceUrl` values.
+- Improved operation summaries for all client resource methods.

--- a/README.md
+++ b/README.md
@@ -175,14 +175,14 @@ companies:SimplePublicObjectInputForCreate newCompany = {
     associations: []
 };
 
-companies:SimplePublicObject response = check hubSpotCrmCompanies->/companies.post(newCompany);
+companies:SimplePublicObject response = check hubSpotCrmCompanies->/.post(newCompany);
 
 ```
 
 #### List companies
 
 ```ballerina
-companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/companies;
+companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/.get();
 
 ```
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.12.0"
 org = "ballerinax"
 name = "hubspot.crm.obj.companies"
-version = "2.0.1"
+version = "3.0.0"
 license = ["Apache-2.0"]
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Area/CRM & Sales", "Vendor/HubSpot"]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -73,7 +73,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -106,7 +106,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -232,7 +232,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -310,7 +310,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -333,7 +333,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.obj.companies"
-version = "2.0.1"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
@@ -345,6 +345,7 @@ dependencies = [
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
-	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"}
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"},
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies.mock.server"}
 ]
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -174,14 +174,14 @@ companies:SimplePublicObjectInputForCreate newCompany = {
     associations: []
 };
 
-companies:SimplePublicObject response = check hubSpotCrmCompanies->/companies.post(newCompany);
+companies:SimplePublicObject response = check hubSpotCrmCompanies->/.post(newCompany);
 
 ```
 
 #### List companies
 
 ```ballerina
-companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/companies;
+companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/.get();
 
 ```
 

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -28,7 +28,7 @@ public isolated client class Client {
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
     # + return - An error if connector initialization failed 
-    public isolated function init(ConnectionConfig config, string serviceUrl = "https://api.hubapi.com/crm/v3/objects") returns error? {
+    public isolated function init(ConnectionConfig config, string serviceUrl = "https://api.hubapi.com/crm/v3/objects/companies") returns error? {
         http:ClientConfiguration httpClientConfig = {httpVersion: config.httpVersion, http1Settings: config.http1Settings, http2Settings: config.http2Settings, timeout: config.timeout, forwarded: config.forwarded, followRedirects: config.followRedirects, poolConfig: config.poolConfig, cache: config.cache, compression: config.compression, circuitBreaker: config.circuitBreaker, retryConfig: config.retryConfig, cookieConfig: config.cookieConfig, responseLimits: config.responseLimits, secureSocket: config.secureSocket, proxy: config.proxy, socketConfig: config.socketConfig, validation: config.validation, laxDataBinding: config.laxDataBinding};
         if config.auth is ApiKeysConfig {
             self.apiKeyConfig = (<ApiKeysConfig>config.auth).cloneReadOnly();
@@ -39,13 +39,13 @@ public isolated client class Client {
         self.clientEp = check new (serviceUrl, httpClientConfig);
     }
 
-    # Read a batch of companies by internal ID, or unique property values
+    # Read companies by ID or property
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/batch/read(BatchReadInputSimplePublicObjectId payload, map<string|string[]> headers = {}, *PostCrmV3ObjectsCompaniesBatchReadReadQueries queries) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
-        string resourcePath = string `/companies/batch/read`;
+    resource isolated function post batch/read(BatchReadInputSimplePublicObjectId payload, map<string|string[]> headers = {}, *PostCrmV3ObjectsCompaniesBatchReadReadQueries queries) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
+        string resourcePath = string `/batch/read`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -58,13 +58,14 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read
+    # Retrieve a company by ID
     #
+    # + companyId - The unique identifier of the company record to retrieve.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
-    resource isolated function get companies/[string companyId](map<string|string[]> headers = {}, *GetCrmV3ObjectsCompaniesCompanyIdGetByIdQueries queries) returns SimplePublicObjectWithAssociations|error {
-        string resourcePath = string `/companies/${getEncodedUri(companyId)}`;
+    resource isolated function get [string companyId](map<string|string[]> headers = {}, *GetCrmV3ObjectsCompaniesCompanyIdGetByIdQueries queries) returns SimplePublicObjectWithAssociations|error {
+        string resourcePath = string `/${getEncodedUri(companyId)}`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -75,12 +76,13 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Archive
+    # Archive a company by ID
     #
+    # + companyId - The unique identifier of the company record to archive.
     # + headers - Headers to be sent with the request 
     # + return - No content 
-    resource isolated function delete companies/[string companyId](map<string|string[]> headers = {}) returns error? {
-        string resourcePath = string `/companies/${getEncodedUri(companyId)}`;
+    resource isolated function delete [string companyId](map<string|string[]> headers = {}) returns error? {
+        string resourcePath = string `/${getEncodedUri(companyId)}`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -89,13 +91,14 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
 
-    # Update
+    # Update a company by ID
     #
+    # + companyId - The unique internal identifier of the company to update.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
-    resource isolated function patch companies/[string companyId](SimplePublicObjectInput payload, map<string|string[]> headers = {}, *PatchCrmV3ObjectsCompaniesCompanyIdUpdateQueries queries) returns SimplePublicObject|error {
-        string resourcePath = string `/companies/${getEncodedUri(companyId)}`;
+    resource isolated function patch [string companyId](SimplePublicObjectInput payload, map<string|string[]> headers = {}, *PatchCrmV3ObjectsCompaniesCompanyIdUpdateQueries queries) returns SimplePublicObject|error {
+        string resourcePath = string `/${getEncodedUri(companyId)}`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -112,8 +115,8 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/merge(PublicMergeInput payload, map<string|string[]> headers = {}) returns SimplePublicObject|error {
-        string resourcePath = string `/companies/merge`;
+    resource isolated function post merge(PublicMergeInput payload, map<string|string[]> headers = {}) returns SimplePublicObject|error {
+        string resourcePath = string `/merge`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -129,8 +132,8 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - No content 
-    resource isolated function post companies/batch/archive(BatchInputSimplePublicObjectId payload, map<string|string[]> headers = {}) returns error? {
-        string resourcePath = string `/companies/batch/archive`;
+    resource isolated function post batch/archive(BatchInputSimplePublicObjectId payload, map<string|string[]> headers = {}) returns error? {
+        string resourcePath = string `/batch/archive`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -146,8 +149,8 @@ public isolated client class Client {
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/batch/create(BatchInputSimplePublicObjectInputForCreate payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
-        string resourcePath = string `/companies/batch/create`;
+    resource isolated function post batch/create(BatchInputSimplePublicObjectInputForCreate payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
+        string resourcePath = string `/batch/create`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -159,12 +162,12 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Update a batch of companies by internal ID, or unique property values
+    # Update companies by ID or property
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/batch/update(BatchInputSimplePublicObjectBatchInput payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
-        string resourcePath = string `/companies/batch/update`;
+    resource isolated function post batch/update(BatchInputSimplePublicObjectBatchInput payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors|error {
+        string resourcePath = string `/batch/update`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -176,13 +179,13 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # List
+    # List a page of companies
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
-    resource isolated function get companies(map<string|string[]> headers = {}, *GetCrmV3ObjectsCompaniesGetPageQueries queries) returns CollectionResponseSimplePublicObjectWithAssociationsForwardPaging|error {
-        string resourcePath = string `/companies`;
+    resource isolated function get .(map<string|string[]> headers = {}, *GetCrmV3ObjectsCompaniesGetPageQueries queries) returns CollectionResponseSimplePublicObjectWithAssociationsForwardPaging|error {
+        string resourcePath = string `/`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -193,12 +196,12 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Create
+    # Create a new company
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies(SimplePublicObjectInputForCreate payload, map<string|string[]> headers = {}) returns SimplePublicObject|error {
-        string resourcePath = string `/companies`;
+    resource isolated function post .(SimplePublicObjectInputForCreate payload, map<string|string[]> headers = {}) returns SimplePublicObject|error {
+        string resourcePath = string `/`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -210,12 +213,12 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Create or update a batch of companies by unique property values
+    # Upsert companies by property
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/batch/upsert(BatchInputSimplePublicObjectBatchInputUpsert payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicUpsertObject|BatchResponseSimplePublicUpsertObjectWithErrors|error {
-        string resourcePath = string `/companies/batch/upsert`;
+    resource isolated function post batch/upsert(BatchInputSimplePublicObjectBatchInputUpsert payload, map<string|string[]> headers = {}) returns BatchResponseSimplePublicUpsertObject|BatchResponseSimplePublicUpsertObjectWithErrors|error {
+        string resourcePath = string `/batch/upsert`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;
@@ -227,10 +230,12 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
+    # Search for companies
+    #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
-    resource isolated function post companies/search(PublicObjectSearchRequest payload, map<string|string[]> headers = {}) returns CollectionResponseWithTotalSimplePublicObjectForwardPaging|error {
-        string resourcePath = string `/companies/search`;
+    resource isolated function post search(PublicObjectSearchRequest payload, map<string|string[]> headers = {}) returns CollectionResponseWithTotalSimplePublicObjectForwardPaging|error {
+        string resourcePath = string `/search`;
         map<anydata> headerValues = {...headers};
         if self.apiKeyConfig is ApiKeysConfig {
             headerValues["private-app"] = self.apiKeyConfig?.privateApp;

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -23,7 +23,7 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
-    # Gets invoked to initialize the `connector`.
+    # Gets invoked to initialize the `connector`
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
@@ -60,7 +60,7 @@ public isolated client class Client {
 
     # Retrieve a company by ID
     #
-    # + companyId - The unique identifier of the company record to retrieve.
+    # + companyId - The unique identifier of the company record to retrieve
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -78,7 +78,7 @@ public isolated client class Client {
 
     # Archive a company by ID
     #
-    # + companyId - The unique identifier of the company record to archive.
+    # + companyId - The unique identifier of the company record to archive
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [string companyId](map<string|string[]> headers = {}) returns error? {
@@ -93,7 +93,7 @@ public isolated client class Client {
 
     # Update a company by ID
     #
-    # + companyId - The unique internal identifier of the company to update.
+    # + companyId - The unique internal identifier of the company to update
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 

--- a/ballerina/tests/mock_service.bal
+++ b/ballerina/tests/mock_service.bal
@@ -19,7 +19,7 @@ import ballerina/log;
 
 service on new http:Listener(9090) {
 
-    resource function get companies(string properties = "", string archived = "false", int:Signed32 'limit = 10) returns json|http:Response {
+    resource function get .(string properties = "", string archived = "false", int:Signed32 'limit = 10) returns json|http:Response {
         log:printInfo("Mock GET request received for companies with properties: " + properties + ", archived: " + archived);
         json mockedResponse = {
             "results": [
@@ -48,7 +48,7 @@ service on new http:Listener(9090) {
         return mockedResponse;
     }
 
-    resource function post companies/batch/read(@http:Payload BatchReadInputSimplePublicObjectId payload)
+    resource function post batch/read(@http:Payload BatchReadInputSimplePublicObjectId payload)
     returns json|http:Response {
 
         log:printInfo("Mock POST request received for batch read with payload: " + payload.toJson().toString());
@@ -94,7 +94,7 @@ service on new http:Listener(9090) {
         return mockedResponse;
     }
 
-    resource function post companies(@http:Payload SimplePublicObjectInputForCreate payload) returns json|http:Response {
+    resource function post .(@http:Payload SimplePublicObjectInputForCreate payload) returns json|http:Response {
         log:printInfo("Mock POST request received for company creation with payload: " + payload.toJson().toString());
 
         // Simulate a successful creation response with the same company data

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -19,7 +19,7 @@ import ballerina/os;
 import ballerina/test;
 
 final boolean isLiveServer = os:getEnv("IS_LIVE_SERVER") == "true";
-final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v3/objects" : "http://localhost:9090";
+final string serviceUrl = isLiveServer ? "https://api.hubapi.com/crm/v3/objects/companies" : "http://localhost:9090";
 
 final string clientId = os:getEnv("HUBSPOT_CLIENT_ID");
 final string clientSecret = os:getEnv("HUBSPOT_CLIENT_SECRET");
@@ -48,7 +48,7 @@ isolated function initClient() returns Client|error {
     groups: ["live_tests", "mock_tests"]
 }
 isolated function testGetAllCompanies() returns error? {
-    CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/companies;
+    CollectionResponseSimplePublicObjectWithAssociationsForwardPaging companies = check hubSpotCrmCompanies->/.get();
     test:assertTrue(companies.results.length() > 0);
 };
 
@@ -65,7 +65,7 @@ isolated function testBatchRead() returns error? {
         properties: []
     };
 
-    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/companies/batch/read.post(payload);
+    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/batch/read.post(payload);
     test:assertTrue(response.results.length() > 0, "Expected non-zero amount of companies");
 }
 
@@ -86,7 +86,7 @@ isolated function testCreateCompanies() returns error? {
         associations: []
     };
 
-    SimplePublicObject response = check hubSpotCrmCompanies->/companies.post(payload);
+    SimplePublicObject response = check hubSpotCrmCompanies->/.post(payload);
     test:assertEquals(response.properties["name"], "Maga", "Expected company name to match");
 }
 
@@ -104,7 +104,7 @@ isolated function testGetCompanies() returns error? {
         properties: ["name", "domain", "hs_object_id"]
     };
 
-    CollectionResponseSimplePublicObjectWithAssociationsForwardPaging response = check hubSpotCrmCompanies->/companies.get(queries = queries);
+    CollectionResponseSimplePublicObjectWithAssociationsForwardPaging response = check hubSpotCrmCompanies->/.get(queries = queries);
     test:assertTrue(response.results.length() > 0, "Expected at least one company to be returned");
 }
 
@@ -122,7 +122,7 @@ isolated function testSearchCompany() returns error? {
         filterGroups: []
     };
 
-    CollectionResponseWithTotalSimplePublicObjectForwardPaging response = check hubSpotCrmCompanies->/companies/search.post(payload);
+    CollectionResponseWithTotalSimplePublicObjectForwardPaging response = check hubSpotCrmCompanies->/search.post(payload);
     test:assertTrue(response.results.length() > 0, "Expected at least one company to match the search criteria");
 
 }
@@ -139,7 +139,7 @@ isolated function testUpdateCompany() returns error? {
             "domain": "updateddomain.com"
         }
     };
-    SimplePublicObject response = check hubSpotCrmCompanies->/companies/[companyId].patch(payload);
+    SimplePublicObject response = check hubSpotCrmCompanies->/[companyId].patch(payload);
     test:assertEquals(response.properties["name"], "Updated TestCompany", "The company name was not updated correctly.");
     test:assertEquals(response.properties["domain"], "updateddomain.com", "The company domain was not updated correctly.");
 }
@@ -151,7 +151,7 @@ isolated function testUpdateCompany() returns error? {
 isolated function testGetCompanyById() returns error? {
     string companyId = "28228574530";
     GetCrmV3ObjectsCompaniesCompanyIdGetByIdQueries queries = {};
-    SimplePublicObjectWithAssociations response = check hubSpotCrmCompanies->/companies/[companyId](queries = queries);
+    SimplePublicObjectWithAssociations response = check hubSpotCrmCompanies->/[companyId](queries = queries);
     test:assertTrue(response.id != "", "No company data was retrieved.");
 
 }
@@ -162,7 +162,7 @@ isolated function testGetCompanyById() returns error? {
 }
 isolated function testDeleteCompany() returns error? {
     string companyId = "28200512883"; // Replace with the actual company ID to be archived
-    _ = check hubSpotCrmCompanies->/companies/[companyId].delete();
+    _ = check hubSpotCrmCompanies->/[companyId].delete();
     test:assertTrue(true, "Company deleted successfully.");
 }
 
@@ -194,7 +194,7 @@ isolated function testBatchUpsert() returns error? {
         ]
     };
 
-    BatchResponseSimplePublicUpsertObject|BatchResponseSimplePublicUpsertObjectWithErrors response = check hubSpotCrmCompanies->/companies/batch/upsert.post(payload);
+    BatchResponseSimplePublicUpsertObject|BatchResponseSimplePublicUpsertObjectWithErrors response = check hubSpotCrmCompanies->/batch/upsert.post(payload);
     test:assertTrue(response.results.length() > 0,
             string `At least one company should be successfully upserted. Found: ${response.results.length()}`);
 
@@ -222,7 +222,7 @@ isolated function testBatchCreate() returns error? {
         ]
     };
 
-    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/companies/batch/create.post(payload);
+    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/batch/create.post(payload);
     test:assertTrue(response !is BatchResponseSimplePublicObjectWithErrors, "Batch creation should return a successful response.");
 }
 
@@ -249,7 +249,7 @@ isolated function testBatchUpdate() returns error? {
             }
         ]
     };
-    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/companies/batch/update.post(payload);
+    BatchResponseSimplePublicObject|BatchResponseSimplePublicObjectWithErrors response = check hubSpotCrmCompanies->/batch/update.post(payload);
     test:assertTrue(response !is BatchResponseSimplePublicObjectWithErrors, "Batch update should return a successful response.");
 }
 
@@ -264,6 +264,6 @@ isolated function testBatchArchive() returns error? {
             {id: "28152220570"}
         ]
     };
-    _ = check hubSpotCrmCompanies->/companies/batch/archive.post(payload);
+    _ = check hubSpotCrmCompanies->/batch/archive.post(payload);
     test:assertTrue(true, "Batch archive should return a successful response.");
 }

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -35,31 +35,31 @@ public type GetCrmV3ObjectsCompaniesGetPageQueries record {
     string[] properties?;
 };
 
-# Standard error response structure returned by the API on failure.
+# Standard error response structure returned by the API on failure
 public type StandardError record {
-    # Optional sub-category providing additional error classification.
+    # Optional sub-category providing additional error classification
     record {} subCategory?;
-    # Key-value map of contextual metadata related to the error.
+    # Key-value map of contextual metadata related to the error
     record {|string[]...;|} context;
-    # Map of relevant links associated with the error response.
+    # Map of relevant links associated with the error response
     record {|string...;|} links;
-    # Unique identifier for the error instance.
+    # Unique identifier for the error instance
     string id?;
-    # High-level category classifying the type of error.
+    # High-level category classifying the type of error
     string category;
-    # Human-readable message describing the error.
+    # Human-readable message describing the error
     string message;
-    # List of detailed error entries associated with this error.
+    # List of detailed error entries associated with this error
     ErrorDetail[] errors;
-    # HTTP status code or status label for the error.
+    # HTTP status code or status label for the error
     string status;
 };
 
-# Paginated collection of associated object IDs.
+# Paginated collection of associated object IDs
 public type CollectionResponseAssociatedId record {
-    # Pagination metadata containing cursors for navigating to the next or previous page.
+    # Pagination metadata containing cursors for navigating to the next or previous page
     Paging paging?;
-    # Array of associated IDs returned in the response.
+    # Array of associated IDs returned in the response
     AssociatedId[] results;
 };
 
@@ -77,37 +77,37 @@ public type GetCrmV3ObjectsCompaniesCompanyIdGetByIdQueries record {
     string[] properties?;
 };
 
-# Defines association targets and types for a given object.
+# Defines association targets and types for a given object
 public type PublicAssociationsForObject record {
-    # List of association type specifications for the relationship.
+    # List of association type specifications for the relationship
     AssociationSpec[] types?;
-    # Represents a unique identifier for a public company object.
+    # Represents a unique identifier for a public company object
     PublicObjectId to?;
 };
 
-# Batch operation response containing results and execution timestamps.
+# Batch operation response containing results and execution timestamps
 public type BatchResponseSimplePublicObject record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation began processing.
+    # Timestamp indicating when the batch operation began processing
     string startedAt;
-    # Map of additional links related to the batch response.
+    # Map of additional links related to the batch response
     record {|string...;|} links?;
-    # Array of company objects returned by the batch operation.
+    # Array of company objects returned by the batch operation
     SimplePublicObject[] results;
-    # Current status of the batch operation.
+    # Current status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A group of filters combined to refine search query results.
+# A group of filters combined to refine search query results
 public type FilterGroup record {
-    # Array of filter conditions applied within this group.
+    # Array of filter conditions applied within this group
     Filter[] filters;
 };
 
-# Detailed information about a specific error encountered in a request.
+# Detailed information about a specific error encountered in a request
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -121,85 +121,85 @@ public type ErrorDetail record {
     string message;
 };
 
-# Pagination object providing a cursor for forward navigation through results.
+# Pagination object providing a cursor for forward navigation through results
 public type ForwardPaging record {
-    # Pagination cursor object used to retrieve the next page of results.
+    # Pagination cursor object used to retrieve the next page of results
     NextPage next?;
 };
 
-# A minimal object representation containing only a unique identifier.
+# A minimal object representation containing only a unique identifier
 public type SimplePublicObjectId record {
-    # The unique identifier of the object.
+    # The unique identifier of the object
     string id;
 };
 
-# Batch upsert response including results, status, timestamps, and any errors encountered.
+# Batch upsert response including results, status, timestamps, and any errors encountered
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
-    # Timestamp when the batch operation completed.
+    # Timestamp when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp when the batch operation was requested.
+    # Timestamp when the batch operation was requested
     string requestedAt?;
-    # Timestamp when the batch operation began processing.
+    # Timestamp when the batch operation began processing
     string startedAt;
-    # Map of relevant links associated with the batch response.
+    # Map of relevant links associated with the batch response
     record {|string...;|} links?;
-    # Array of upserted company objects returned by the batch operation.
+    # Array of upserted company objects returned by the batch operation
     SimplePublicUpsertObject[] results;
-    # Array of errors encountered for individual records in the batch.
+    # Array of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current status of the batch upsert operation.
+    # Current status of the batch upsert operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input schema for a batch read request, specifying object IDs and properties to retrieve.
+# Input schema for a batch read request, specifying object IDs and properties to retrieve
 public type BatchReadInputSimplePublicObjectId record {
-    # List of properties for which historical values should be returned.
+    # List of properties for which historical values should be returned
     string[] propertiesWithHistory;
-    # The property to use as the unique identifier for lookup.
+    # The property to use as the unique identifier for lookup
     string idProperty?;
-    # Array of object IDs to retrieve in the batch read.
+    # Array of object IDs to retrieve in the batch read
     SimplePublicObjectId[] inputs;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties;
 };
 
-# Batch response containing upserted company objects with processing status and timestamps.
+# Batch response containing upserted company objects with processing status and timestamps
 public type BatchResponseSimplePublicUpsertObject record {
-    # Datetime when the batch operation completed.
+    # Datetime when the batch operation completed
     string completedAt;
-    # Datetime when the batch operation was requested.
+    # Datetime when the batch operation was requested
     string requestedAt?;
-    # Datetime when the batch operation began processing.
+    # Datetime when the batch operation began processing
     string startedAt;
-    # Map of relevant links associated with the batch response.
+    # Map of relevant links associated with the batch response
     record {|string...;|} links?;
-    # Array of upserted company objects returned by the batch operation.
+    # Array of upserted company objects returned by the batch operation
     SimplePublicUpsertObject[] results;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A property value paired with its source metadata and the timestamp of last update.
+# A property value paired with its source metadata and the timestamp of last update
 public type ValueWithTimestamp record {
-    # Identifier of the source that set this value.
+    # Identifier of the source that set this value
     string sourceId?;
-    # The type of source that provided this value.
+    # The type of source that provided this value
     string sourceType;
-    # Human-readable label describing the value's source.
+    # Human-readable label describing the value's source
     string sourceLabel?;
-    # ID of the user who last updated this value.
+    # ID of the user who last updated this value
     int:Signed32 updatedByUserId?;
-    # The property value as a string.
+    # The property value as a string
     string value;
-    # Datetime when this value was last updated.
+    # Datetime when this value was last updated
     string timestamp;
 };
 
-# Input schema for a batch operation containing a list of company object IDs.
+# Input schema for a batch operation containing a list of company object IDs
 public type BatchInputSimplePublicObjectId record {
-    # Array of company object IDs to process in the batch.
+    # Array of company object IDs to process in the batch
     SimplePublicObjectId[] inputs;
 };
 
@@ -216,44 +216,44 @@ public type OAuth2RefreshTokenGrantConfig record {|
     string refreshUrl = "https://api.hubapi.com/oauth/v1/token";
 |};
 
-# Input schema for a batch upsert operation containing company objects to create or update.
+# Input schema for a batch upsert operation containing company objects to create or update
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
-    # Array of company records to upsert in the batch operation.
+    # Array of company records to upsert in the batch operation
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
-# A paginated collection of company records with a total count and forward paging cursor.
+# A paginated collection of company records with a total count and forward paging cursor
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
-    # Total number of company records matching the request.
+    # Total number of company records matching the request
     int:Signed32 total;
-    # Pagination object providing a cursor for forward navigation through results.
+    # Pagination object providing a cursor for forward navigation through results
     ForwardPaging paging?;
-    # Array of company records returned in the current page.
+    # Array of company records returned in the current page
     SimplePublicObject[] results;
 };
 
-# Represents a single company record with its properties, timestamps, and archival status.
+# Represents a single company record with its properties, timestamps, and archival status
 public type SimplePublicObject record {
-    # Timestamp when the company record was created.
+    # Timestamp when the company record was created
     string createdAt;
-    # Indicates whether the company record is archived.
+    # Indicates whether the company record is archived
     boolean archived?;
-    # Timestamp when the company record was archived.
+    # Timestamp when the company record was archived
     string archivedAt?;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # The unique identifier of the company record.
+    # The unique identifier of the company record
     string id;
-    # Map of property names to their current values for the company.
+    # Map of property names to their current values for the company
     record {|string?...;|} properties;
-    # Timestamp when the company record was last updated.
+    # Timestamp when the company record was last updated
     string updatedAt;
 };
 
-# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
+# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
+    # Provides Auth configurations needed when communicating with a remote HTTP endpoint
     http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
@@ -290,13 +290,13 @@ public type ConnectionConfig record {|
     # Enables the inbound payload validation functionality which provided by the constraint package. Enabled by default
     boolean validation = true;
     # Enables relaxed data binding on the client side. When enabled, `nil` values are treated as optional, 
-    # and absent fields are handled as `nilable` types. Enabled by default.
+    # and absent fields are handled as `nilable` types. Enabled by default
     boolean laxDataBinding = true;
 |};
 
-# Represents a unique identifier for a public company object.
+# Represents a unique identifier for a public company object
 public type PublicObjectId record {
-    # The unique identifier string of the company object.
+    # The unique identifier string of the company object
     string id?;
 };
 
@@ -306,208 +306,208 @@ public type PostCrmV3ObjectsCompaniesBatchReadReadQueries record {
     boolean archived = false;
 };
 
-# Pagination metadata containing cursors for navigating to the next or previous page.
+# Pagination metadata containing cursors for navigating to the next or previous page
 public type Paging record {
-    # Pagination cursor object used to retrieve the next page of results.
+    # Pagination cursor object used to retrieve the next page of results
     NextPage next?;
-    # Pagination cursor reference pointing to the previous page of results.
+    # Pagination cursor reference pointing to the previous page of results
     PreviousPage prev?;
 };
 
-# Request payload for searching company records with filters, sorting, and pagination.
+# Request payload for searching company records with filters, sorting, and pagination
 public type PublicObjectSearchRequest record {
-    # Full-text search query string to match against company records.
+    # Full-text search query string to match against company records
     string query?;
-    # Maximum number of results to return in the response.
+    # Maximum number of results to return in the response
     int:Signed32 'limit?;
-    # Cursor token for retrieving the next page of results.
+    # Cursor token for retrieving the next page of results
     string after?;
-    # List of property names to sort results by.
+    # List of property names to sort results by
     string[] sorts?;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties?;
-    # Groups of filters used to narrow search results.
+    # Groups of filters used to narrow search results
     FilterGroup[] filterGroups?;
 };
 
-# Input payload for upserting a single company record in a batch operation, including its ID and properties.
+# Input payload for upserting a single company record in a batch operation, including its ID and properties
 public type SimplePublicObjectBatchInputUpsert record {
-    # The property name used as the unique identifier for the upsert.
+    # The property name used as the unique identifier for the upsert
     string idProperty?;
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # The unique identifier of the company record to upsert.
+    # The unique identifier of the company record to upsert
     string id;
-    # Key-value map of company property names and their values.
+    # Key-value map of company property names and their values
     record {|string...;|} properties;
 };
 
-# Batch operation response containing company results, processing status, timestamps, and any errors encountered.
+# Batch operation response containing company results, processing status, timestamps, and any errors encountered
 public type BatchResponseSimplePublicObjectWithErrors record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation started processing.
+    # Timestamp indicating when the batch operation started processing
     string startedAt;
-    # Map of relevant link names to their associated URIs.
+    # Map of relevant link names to their associated URIs
     record {|string...;|} links?;
-    # List of successfully processed company objects from the batch.
+    # List of successfully processed company objects from the batch
     SimplePublicObject[] results;
-    # List of errors encountered for individual records in the batch.
+    # List of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input payload for creating or updating a company object with its properties.
+# Input payload for creating or updating a company object with its properties
 public type SimplePublicObjectInput record {
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # Key-value map of company property names and their values.
+    # Key-value map of company property names and their values
     record {|string...;|} properties;
 };
 
-# Paginated collection of company objects including their associations.
+# Paginated collection of company objects including their associations
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
-    # Pagination object providing a cursor for forward navigation through results.
+    # Pagination object providing a cursor for forward navigation through results
     ForwardPaging paging?;
-    # Array of company objects returned in the current page.
+    # Array of company objects returned in the current page
     SimplePublicObjectWithAssociations[] results;
 };
 
-# Input payload specifying the two company records to merge.
+# Input payload specifying the two company records to merge
 public type PublicMergeInput record {
-    # ID of the secondary company to be merged and removed.
+    # ID of the secondary company to be merged and removed
     string objectIdToMerge;
-    # ID of the primary company that will be retained after merge.
+    # ID of the primary company that will be retained after merge
     string primaryObjectId;
 };
 
-# Defines the category and type of an association between objects.
+# Defines the category and type of an association between objects
 public type AssociationSpec record {
-    # The category that defines the association's origin or ownership.
+    # The category that defines the association's origin or ownership
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory?;
-    # Numeric identifier for the specific association type.
+    # Numeric identifier for the specific association type
     int:Signed32 associationTypeId?;
 };
 
-# A company object including its properties, associations, and timestamps.
+# A company object including its properties, associations, and timestamps
 public type SimplePublicObjectWithAssociations record {
-    # Map of associated object collections keyed by association type.
+    # Map of associated object collections keyed by association type
     record {|CollectionResponseAssociatedId...;|} associations?;
-    # Timestamp indicating when the company record was created.
+    # Timestamp indicating when the company record was created
     string createdAt;
-    # Indicates whether the company record is archived.
+    # Indicates whether the company record is archived
     boolean archived?;
-    # Timestamp indicating when the company record was archived.
+    # Timestamp indicating when the company record was archived
     string archivedAt?;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # Unique identifier of the company record.
+    # Unique identifier of the company record
     string id;
-    # Key-value map of the company's current property values.
+    # Key-value map of the company's current property values
     record {|string?...;|} properties;
-    # Timestamp of the last update to the object.
+    # Timestamp of the last update to the object
     string updatedAt;
 };
 
-# Defines a filter condition used to query company records by property, operator, and value.
+# Defines a filter condition used to query company records by property, operator, and value
 public type Filter record {
-    # Upper bound value for BETWEEN range filter operations.
+    # Upper bound value for BETWEEN range filter operations
     string highValue?;
-    # The company property name to evaluate in the filter.
+    # The company property name to evaluate in the filter
     string propertyName;
-    # List of values used with IN or NOT_IN filter operators.
+    # List of values used with IN or NOT_IN filter operators
     string[] values?;
-    # The single value to compare against the specified property.
+    # The single value to compare against the specified property
     string value?;
-    # Comparison operator that defines how the property is evaluated against the value.
+    # Comparison operator that defines how the property is evaluated against the value
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
-# Pagination cursor reference pointing to the previous page of results.
+# Pagination cursor reference pointing to the previous page of results
 public type PreviousPage record {
-    # Cursor token representing the start of the previous page.
+    # Cursor token representing the start of the previous page
     string before;
-    # Navigable URL link to the previous page of results.
+    # Navigable URL link to the previous page of results
     string link?;
 };
 
-# Wraps a collection of company creation inputs for batch processing.
+# Wraps a collection of company creation inputs for batch processing
 public type BatchInputSimplePublicObjectInputForCreate record {
-    # Array of company creation payloads to process in batch.
+    # Array of company creation payloads to process in batch
     SimplePublicObjectInputForCreate[] inputs;
 };
 
-# Wraps a collection of company update inputs for batch processing.
+# Wraps a collection of company update inputs for batch processing
 public type BatchInputSimplePublicObjectBatchInput record {
-    # Array of company property update payloads to process in batch.
+    # Array of company property update payloads to process in batch
     SimplePublicObjectBatchInput[] inputs;
 };
 
-# Represents a company record returned after an upsert operation, indicating whether it was newly created.
+# Represents a company record returned after an upsert operation, indicating whether it was newly created
 public type SimplePublicUpsertObject record {
-    # Timestamp when the company record was created.
+    # Timestamp when the company record was created
     string createdAt;
-    # Indicates whether the company record is archived.
+    # Indicates whether the company record is archived
     boolean archived?;
-    # Timestamp when the company record was archived.
+    # Timestamp when the company record was archived
     string archivedAt?;
-    # Indicates whether the record was created new during the upsert.
+    # Indicates whether the record was created new during the upsert
     boolean 'new;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # Unique identifier of the upserted company object.
+    # Unique identifier of the upserted company object
     string id;
-    # Key-value map of company property names to their values.
+    # Key-value map of company property names to their values
     record {|string...;|} properties;
-    # Timestamp indicating when the company record was last updated.
+    # Timestamp indicating when the company record was last updated
     string updatedAt;
 };
 
-# Input payload for updating a single company in a batch operation, including its identifier and property values.
+# Input payload for updating a single company in a batch operation, including its identifier and property values
 public type SimplePublicObjectBatchInput record {
-    # Name of a unique property used to identify the company instead of the default record ID.
+    # Name of a unique property used to identify the company instead of the default record ID
     string idProperty?;
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # Unique identifier of the company record to update.
+    # Unique identifier of the company record to update
     string id;
-    # Key-value map of company property names to their updated values.
+    # Key-value map of company property names to their updated values
     record {|string...;|} properties;
 };
 
-# Pagination cursor object used to retrieve the next page of results.
+# Pagination cursor object used to retrieve the next page of results
 public type NextPage record {
-    # Relative URL to fetch the next page of results.
+    # Relative URL to fetch the next page of results
     string link?;
-    # Cursor token representing the position after the last returned result.
+    # Cursor token representing the position after the last returned result
     string after;
 };
 
-# Represents an associated object reference, defined by its ID and association type.
+# Represents an associated object reference, defined by its ID and association type
 public type AssociatedId record {
-    # Unique identifier of the associated object.
+    # Unique identifier of the associated object
     string id;
-    # Type label describing the nature of the association.
+    # Type label describing the nature of the association
     string 'type;
 };
 
-# Provides API key configurations needed when communicating with a remote HTTP endpoint.
+# Provides API key configurations needed when communicating with a remote HTTP endpoint
 public type ApiKeysConfig record {|
     string privateAppLegacy;
     string privateApp;
 |};
 
-# Input payload for creating a new company, including its properties and optional associations.
+# Input payload for creating a new company, including its properties and optional associations
 public type SimplePublicObjectInputForCreate record {
-    # List of associations linking the new company to other CRM objects.
+    # List of associations linking the new company to other CRM objects
     PublicAssociationsForObject[] associations?;
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # Key-value map of company property names to their initial values.
+    # Key-value map of company property names to their initial values
     record {|string...;|} properties;
 };

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -35,19 +35,31 @@ public type GetCrmV3ObjectsCompaniesGetPageQueries record {
     string[] properties?;
 };
 
+# Standard error response structure returned by the API on failure.
 public type StandardError record {
+    # Optional sub-category providing additional error classification.
     record {} subCategory?;
+    # Key-value map of contextual metadata related to the error.
     record {|string[]...;|} context;
+    # Map of relevant links associated with the error response.
     record {|string...;|} links;
+    # Unique identifier for the error instance.
     string id?;
+    # High-level category classifying the type of error.
     string category;
+    # Human-readable message describing the error.
     string message;
+    # List of detailed error entries associated with this error.
     ErrorDetail[] errors;
+    # HTTP status code or status label for the error.
     string status;
 };
 
+# Paginated collection of associated object IDs.
 public type CollectionResponseAssociatedId record {
+    # Pagination metadata containing cursors for navigating to the next or previous page.
     Paging paging?;
+    # Array of associated IDs returned in the response.
     AssociatedId[] results;
 };
 
@@ -65,24 +77,37 @@ public type GetCrmV3ObjectsCompaniesCompanyIdGetByIdQueries record {
     string[] properties?;
 };
 
+# Defines association targets and types for a given object.
 public type PublicAssociationsForObject record {
+    # List of association type specifications for the relationship.
     AssociationSpec[] types?;
+    # Represents a unique identifier for a public company object.
     PublicObjectId to?;
 };
 
+# Batch operation response containing results and execution timestamps.
 public type BatchResponseSimplePublicObject record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation began processing.
     string startedAt;
+    # Map of additional links related to the batch response.
     record {|string...;|} links?;
+    # Array of company objects returned by the batch operation.
     SimplePublicObject[] results;
+    # Current status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A group of filters combined to refine search query results.
 public type FilterGroup record {
+    # Array of filter conditions applied within this group.
     Filter[] filters;
 };
 
+# Detailed information about a specific error encountered in a request.
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -96,51 +121,85 @@ public type ErrorDetail record {
     string message;
 };
 
+# Pagination object providing a cursor for forward navigation through results.
 public type ForwardPaging record {
+    # Pagination cursor object used to retrieve the next page of results.
     NextPage next?;
 };
 
+# A minimal object representation containing only a unique identifier.
 public type SimplePublicObjectId record {
+    # The unique identifier of the object.
     string id;
 };
 
+# Batch upsert response including results, status, timestamps, and any errors encountered.
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
+    # Timestamp when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp when the batch operation was requested.
     string requestedAt?;
+    # Timestamp when the batch operation began processing.
     string startedAt;
+    # Map of relevant links associated with the batch response.
     record {|string...;|} links?;
+    # Array of upserted company objects returned by the batch operation.
     SimplePublicUpsertObject[] results;
+    # Array of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current status of the batch upsert operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input schema for a batch read request, specifying object IDs and properties to retrieve.
 public type BatchReadInputSimplePublicObjectId record {
+    # List of properties for which historical values should be returned.
     string[] propertiesWithHistory;
+    # The property to use as the unique identifier for lookup.
     string idProperty?;
+    # Array of object IDs to retrieve in the batch read.
     SimplePublicObjectId[] inputs;
+    # List of property names to include in the response.
     string[] properties;
 };
 
+# Batch response containing upserted company objects with processing status and timestamps.
 public type BatchResponseSimplePublicUpsertObject record {
+    # Datetime when the batch operation completed.
     string completedAt;
+    # Datetime when the batch operation was requested.
     string requestedAt?;
+    # Datetime when the batch operation began processing.
     string startedAt;
+    # Map of relevant links associated with the batch response.
     record {|string...;|} links?;
+    # Array of upserted company objects returned by the batch operation.
     SimplePublicUpsertObject[] results;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A property value paired with its source metadata and the timestamp of last update.
 public type ValueWithTimestamp record {
+    # Identifier of the source that set this value.
     string sourceId?;
+    # The type of source that provided this value.
     string sourceType;
+    # Human-readable label describing the value's source.
     string sourceLabel?;
+    # ID of the user who last updated this value.
     int:Signed32 updatedByUserId?;
+    # The property value as a string.
     string value;
+    # Datetime when this value was last updated.
     string timestamp;
 };
 
+# Input schema for a batch operation containing a list of company object IDs.
 public type BatchInputSimplePublicObjectId record {
+    # Array of company object IDs to process in the batch.
     SimplePublicObjectId[] inputs;
 };
 
@@ -157,23 +216,37 @@ public type OAuth2RefreshTokenGrantConfig record {|
     string refreshUrl = "https://api.hubapi.com/oauth/v1/token";
 |};
 
+# Input schema for a batch upsert operation containing company objects to create or update.
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
+    # Array of company records to upsert in the batch operation.
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
+# A paginated collection of company records with a total count and forward paging cursor.
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
+    # Total number of company records matching the request.
     int:Signed32 total;
+    # Pagination object providing a cursor for forward navigation through results.
     ForwardPaging paging?;
+    # Array of company records returned in the current page.
     SimplePublicObject[] results;
 };
 
+# Represents a single company record with its properties, timestamps, and archival status.
 public type SimplePublicObject record {
+    # Timestamp when the company record was created.
     string createdAt;
+    # Indicates whether the company record is archived.
     boolean archived?;
+    # Timestamp when the company record was archived.
     string archivedAt?;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # The unique identifier of the company record.
     string id;
+    # Map of property names to their current values for the company.
     record {|string?...;|} properties;
+    # Timestamp when the company record was last updated.
     string updatedAt;
 };
 
@@ -221,7 +294,9 @@ public type ConnectionConfig record {|
     boolean laxDataBinding = true;
 |};
 
+# Represents a unique identifier for a public company object.
 public type PublicObjectId record {
+    # The unique identifier string of the company object.
     string id?;
 };
 
@@ -231,116 +306,193 @@ public type PostCrmV3ObjectsCompaniesBatchReadReadQueries record {
     boolean archived = false;
 };
 
+# Pagination metadata containing cursors for navigating to the next or previous page.
 public type Paging record {
+    # Pagination cursor object used to retrieve the next page of results.
     NextPage next?;
+    # Pagination cursor reference pointing to the previous page of results.
     PreviousPage prev?;
 };
 
+# Request payload for searching company records with filters, sorting, and pagination.
 public type PublicObjectSearchRequest record {
+    # Full-text search query string to match against company records.
     string query?;
+    # Maximum number of results to return in the response.
     int:Signed32 'limit?;
+    # Cursor token for retrieving the next page of results.
     string after?;
+    # List of property names to sort results by.
     string[] sorts?;
+    # List of property names to include in the response.
     string[] properties?;
+    # Groups of filters used to narrow search results.
     FilterGroup[] filterGroups?;
 };
 
+# Input payload for upserting a single company record in a batch operation, including its ID and properties.
 public type SimplePublicObjectBatchInputUpsert record {
+    # The property name used as the unique identifier for the upsert.
     string idProperty?;
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # The unique identifier of the company record to upsert.
     string id;
+    # Key-value map of company property names and their values.
     record {|string...;|} properties;
 };
 
+# Batch operation response containing company results, processing status, timestamps, and any errors encountered.
 public type BatchResponseSimplePublicObjectWithErrors record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation started processing.
     string startedAt;
+    # Map of relevant link names to their associated URIs.
     record {|string...;|} links?;
+    # List of successfully processed company objects from the batch.
     SimplePublicObject[] results;
+    # List of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input payload for creating or updating a company object with its properties.
 public type SimplePublicObjectInput record {
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # Key-value map of company property names and their values.
     record {|string...;|} properties;
 };
 
+# Paginated collection of company objects including their associations.
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
+    # Pagination object providing a cursor for forward navigation through results.
     ForwardPaging paging?;
+    # Array of company objects returned in the current page.
     SimplePublicObjectWithAssociations[] results;
 };
 
+# Input payload specifying the two company records to merge.
 public type PublicMergeInput record {
+    # ID of the secondary company to be merged and removed.
     string objectIdToMerge;
+    # ID of the primary company that will be retained after merge.
     string primaryObjectId;
 };
 
+# Defines the category and type of an association between objects.
 public type AssociationSpec record {
+    # The category that defines the association's origin or ownership.
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory?;
+    # Numeric identifier for the specific association type.
     int:Signed32 associationTypeId?;
 };
 
+# A company object including its properties, associations, and timestamps.
 public type SimplePublicObjectWithAssociations record {
+    # Map of associated object collections keyed by association type.
     record {|CollectionResponseAssociatedId...;|} associations?;
+    # Timestamp indicating when the company record was created.
     string createdAt;
+    # Indicates whether the company record is archived.
     boolean archived?;
+    # Timestamp indicating when the company record was archived.
     string archivedAt?;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # Unique identifier of the company record.
     string id;
+    # Key-value map of the company's current property values.
     record {|string?...;|} properties;
+    # Timestamp of the last update to the object.
     string updatedAt;
 };
 
+# Defines a filter condition used to query company records by property, operator, and value.
 public type Filter record {
+    # Upper bound value for BETWEEN range filter operations.
     string highValue?;
+    # The company property name to evaluate in the filter.
     string propertyName;
+    # List of values used with IN or NOT_IN filter operators.
     string[] values?;
+    # The single value to compare against the specified property.
     string value?;
-    # null
+    # Comparison operator that defines how the property is evaluated against the value.
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
+# Pagination cursor reference pointing to the previous page of results.
 public type PreviousPage record {
+    # Cursor token representing the start of the previous page.
     string before;
+    # Navigable URL link to the previous page of results.
     string link?;
 };
 
+# Wraps a collection of company creation inputs for batch processing.
 public type BatchInputSimplePublicObjectInputForCreate record {
+    # Array of company creation payloads to process in batch.
     SimplePublicObjectInputForCreate[] inputs;
 };
 
+# Wraps a collection of company update inputs for batch processing.
 public type BatchInputSimplePublicObjectBatchInput record {
+    # Array of company property update payloads to process in batch.
     SimplePublicObjectBatchInput[] inputs;
 };
 
+# Represents a company record returned after an upsert operation, indicating whether it was newly created.
 public type SimplePublicUpsertObject record {
+    # Timestamp when the company record was created.
     string createdAt;
+    # Indicates whether the company record is archived.
     boolean archived?;
+    # Timestamp when the company record was archived.
     string archivedAt?;
+    # Indicates whether the record was created new during the upsert.
     boolean 'new;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # Unique identifier of the upserted company object.
     string id;
+    # Key-value map of company property names to their values.
     record {|string...;|} properties;
+    # Timestamp indicating when the company record was last updated.
     string updatedAt;
 };
 
+# Input payload for updating a single company in a batch operation, including its identifier and property values.
 public type SimplePublicObjectBatchInput record {
+    # Name of a unique property used to identify the company instead of the default record ID.
     string idProperty?;
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # Unique identifier of the company record to update.
     string id;
+    # Key-value map of company property names to their updated values.
     record {|string...;|} properties;
 };
 
+# Pagination cursor object used to retrieve the next page of results.
 public type NextPage record {
+    # Relative URL to fetch the next page of results.
     string link?;
+    # Cursor token representing the position after the last returned result.
     string after;
 };
 
+# Represents an associated object reference, defined by its ID and association type.
 public type AssociatedId record {
+    # Unique identifier of the associated object.
     string id;
+    # Type label describing the nature of the association.
     string 'type;
 };
 
@@ -350,8 +502,12 @@ public type ApiKeysConfig record {|
     string privateApp;
 |};
 
+# Input payload for creating a new company, including its properties and optional associations.
 public type SimplePublicObjectInputForCreate record {
+    # List of associations linking the new company to other CRM objects.
     PublicAssociationsForObject[] associations?;
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # Key-value map of company property names to their initial values.
     record {|string...;|} properties;
 };

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,2172 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Companies",
+        "description": "",
+        "version": "v3",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "FREE",
+            "sales": "FREE",
+            "service": "FREE",
+            "cms": "FREE"
+        },
+        "x-hubspot-documentation-banner": "NONE",
+        "x-hubspot-api-use-case": "When a new customer signs up on your website with their business email address, create a company record to represent the relationship between the customer and the company they work for. A sales rep can later use this company record for outreach to find other potential sales opportunities. ",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Companies Guide",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/crm/objects/companies"
+            }
+        ],
+        "x-hubspot-introduction": "Use the companies API to create and manage CRM records that represent the companies and organizations that interact with your business."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/crm/v3/objects/companies"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Batch"
+        },
+        {
+            "name": "Basic"
+        },
+        {
+            "name": "Merge"
+        },
+        {
+            "name": "Search"
+        }
+    ],
+    "paths": {
+        "/batch/read": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Read companies by ID or property",
+                "operationId": "post-/crm/v3/objects/companies/batch/read_read",
+                "parameters": [
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchReadInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.read"
+                        ]
+                    }
+                ],
+                "description": "Returns a batch of company objects retrieved by internal ID or unique property values, with partial success indicated by a 207 response."
+            }
+        },
+        "/{companyId}": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Retrieve a company by ID",
+                "description": "Read an Object identified by `{companyId}`. `{companyId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+                "operationId": "get-/crm/v3/objects/companies/{companyId}_getById",
+                "parameters": [
+                    {
+                        "name": "companyId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the company record to retrieve."
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.read"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Archive a company by ID",
+                "description": "Move an Object identified by `{companyId}` to the recycling bin.",
+                "operationId": "delete-/crm/v3/objects/companies/{companyId}_archive",
+                "parameters": [
+                    {
+                        "name": "companyId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of the company record to archive."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Update a company by ID",
+                "description": "Perform a partial update of an Object identified by `{companyId}`or optionally a unique property value as specified by the `idProperty` query param. `{companyId}` refers to the internal object ID by default, and the `idProperty` query param refers to a property whose values are unique for the object. Provided property values will be overwritten. Read-only and non-existent properties will result in an error. Properties values can be cleared by passing an empty string.",
+                "operationId": "patch-/crm/v3/objects/companies/{companyId}_update",
+                "parameters": [
+                    {
+                        "name": "companyId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique internal identifier of the company to update."
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/merge": {
+            "post": {
+                "tags": [
+                    "Merge"
+                ],
+                "summary": "Merge two companies with same type",
+                "operationId": "post-/crm/v3/objects/companies/merge_merge",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicMergeInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ],
+                "description": "Returns the merged company object resulting from combining two companies of the same type."
+            }
+        },
+        "/batch/archive": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Archive a batch of companies by ID",
+                "operationId": "post-/crm/v3/objects/companies/batch/archive_archive",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ],
+                "description": "Archives the specified batch of companies by ID. Returns no content on success (204)."
+            }
+        },
+        "/batch/create": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Create a batch of companies",
+                "operationId": "post-/crm/v3/objects/companies/batch/create_create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ],
+                "description": "Returns the batch of newly created company objects, with partial success indicated by a 207 response."
+            }
+        },
+        "/batch/update": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Update companies by ID or property",
+                "operationId": "post-/crm/v3/objects/companies/batch/update_update",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ],
+                "description": "Returns the batch of updated company objects identified by internal ID or unique property values, with partial success indicated by a 207 response."
+            }
+        },
+        "/": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "List a page of companies",
+                "description": "Read a page of companies. Control what is returned via the `properties` query param.",
+                "operationId": "get-/crm/v3/objects/companies_getPage",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of results to display per page",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.read"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Create a new company",
+                "description": "Create a company with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard companies is provided.",
+                "operationId": "post-/crm/v3/objects/companies_create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/upsert": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Upsert companies by property",
+                "description": "Create or update records identified by a unique property value as specified by the `idProperty` query param. `idProperty` query param refers to a property whose values are unique for the object.",
+                "operationId": "post-/crm/v3/objects/companies/batch/upsert_upsert",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.write"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.write"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/search": {
+            "post": {
+                "tags": [
+                    "Search"
+                ],
+                "operationId": "post-/crm/v3/objects/companies/search_doSearch",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicObjectSearchRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2": [
+                            "crm.objects.companies.read"
+                        ]
+                    },
+                    {
+                        "private_apps": [
+                            "crm.objects.companies.read"
+                        ]
+                    }
+                ],
+                "x-hubspot-rate-limit-exemptions": [
+                    "ten-secondly"
+                ],
+                "description": "Returns a list of company objects matching the specified search criteria and filters.",
+                "summary": "Search for companies"
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "StandardError": {
+                "required": [
+                    "category",
+                    "context",
+                    "errors",
+                    "links",
+                    "message",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "Optional sub-category providing additional error classification."
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Key-value map of contextual metadata related to the error."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the error response."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the error instance."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "High-level category classifying the type of error."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable message describing the error."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        },
+                        "description": "List of detailed error entries associated with this error."
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "HTTP status code or status label for the error."
+                    }
+                },
+                "description": "Standard error response structure returned by the API on failure."
+            },
+            "CollectionResponseAssociatedId": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/Paging",
+                        "description": "Pagination details for navigating the result set."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociatedId"
+                        },
+                        "description": "Array of associated IDs returned in the response."
+                    }
+                },
+                "description": "Paginated collection of associated object IDs."
+            },
+            "PublicAssociationsForObject": {
+                "type": "object",
+                "properties": {
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociationSpec"
+                        },
+                        "description": "List of association type specifications for the relationship."
+                    },
+                    "to": {
+                        "$ref": "#/components/schemas/PublicObjectId",
+                        "description": "The target object to associate with."
+                    }
+                },
+                "description": "Defines association targets and types for a given object."
+            },
+            "BatchResponseSimplePublicObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of additional links related to the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "Array of company objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current status of the batch operation."
+                    }
+                },
+                "description": "Batch operation response containing results and execution timestamps."
+            },
+            "FilterGroup": {
+                "required": [
+                    "filters"
+                ],
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Filter"
+                        },
+                        "description": "Array of filter conditions applied within this group."
+                    }
+                },
+                "description": "A group of filters combined to refine search query results."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed information about a specific error encountered in a request."
+            },
+            "ForwardPaging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link details for retrieving the next page of results."
+                    }
+                },
+                "description": "Pagination object providing a cursor for forward navigation through results."
+            },
+            "SimplePublicObjectId": {
+                "required": [
+                    "id"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the object."
+                    }
+                },
+                "description": "A minimal object representation containing only a unique identifier."
+            },
+            "BatchResponseSimplePublicUpsertObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "Array of upserted company objects returned by the batch operation."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "Array of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current status of the batch upsert operation."
+                    }
+                },
+                "description": "Batch upsert response including results, status, timestamps, and any errors encountered."
+            },
+            "BatchReadInputSimplePublicObjectId": {
+                "required": [
+                    "inputs",
+                    "properties",
+                    "propertiesWithHistory"
+                ],
+                "type": "object",
+                "properties": {
+                    "propertiesWithHistory": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of properties for which historical values should be returned."
+                    },
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The property to use as the unique identifier for lookup."
+                    },
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "Array of object IDs to retrieve in the batch read."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    }
+                },
+                "description": "Input schema for a batch read request, specifying object IDs and properties to retrieve."
+            },
+            "BatchResponseSimplePublicUpsertObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Datetime when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Datetime when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Datetime when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "Array of upserted company objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch response containing upserted company objects with processing status and timestamps."
+            },
+            "BatchInputSimplePublicObjectId": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "Array of company object IDs to process in the batch."
+                    }
+                },
+                "description": "Input schema for a batch operation containing a list of company object IDs."
+            },
+            "ValueWithTimestamp": {
+                "required": [
+                    "sourceType",
+                    "timestamp",
+                    "value"
+                ],
+                "type": "object",
+                "properties": {
+                    "sourceId": {
+                        "type": "string",
+                        "description": "Identifier of the source that set this value."
+                    },
+                    "sourceType": {
+                        "type": "string",
+                        "description": "The type of source that provided this value."
+                    },
+                    "sourceLabel": {
+                        "type": "string",
+                        "description": "Human-readable label describing the value's source."
+                    },
+                    "updatedByUserId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "ID of the user who last updated this value."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The property value as a string."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Datetime when this value was last updated."
+                    }
+                },
+                "description": "A property value paired with its source metadata and the timestamp of last update."
+            },
+            "BatchInputSimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+                        },
+                        "description": "Array of company records to upsert in the batch operation."
+                    }
+                },
+                "description": "Input schema for a batch upsert operation containing company objects to create or update."
+            },
+            "CollectionResponseWithTotalSimplePublicObjectForwardPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of company records matching the request."
+                    },
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next page of results."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "Array of company records returned in the current page."
+                    }
+                },
+                "description": "A paginated collection of company records with a total count and forward paging cursor."
+            },
+            "SimplePublicObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the company record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "example": false,
+                        "description": "Indicates whether the company record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the company record was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "example": "512",
+                        "description": "The unique identifier of the company record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Map of property names to their current values for the company."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the company record was last updated."
+                    }
+                },
+                "example": {
+                    "id": "512",
+                    "properties": {
+                        "city": "Cambridge",
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "domain": "biglytics.net",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "industry": "Technology",
+                        "name": "Biglytics",
+                        "phone": "(877) 929-0687",
+                        "state": "Massachusetts"
+                    },
+                    "createdAt": "2019-10-30T03:30:17.883Z",
+                    "updatedAt": "2019-12-07T16:50:06.678Z",
+                    "archived": false
+                },
+                "description": "Represents a single company record with its properties, timestamps, and archival status."
+            },
+            "PublicObjectId": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier string of the company object."
+                    }
+                },
+                "description": "Represents a unique identifier for a public company object."
+            },
+            "Paging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link information for the next page of results."
+                    },
+                    "prev": {
+                        "$ref": "#/components/schemas/PreviousPage",
+                        "description": "Cursor and link information for the previous page of results."
+                    }
+                },
+                "description": "Pagination metadata containing cursors for navigating to the next or previous page."
+            },
+            "PublicObjectSearchRequest": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Full-text search query string to match against company records."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Maximum number of results to return in the response."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Cursor token for retrieving the next page of results."
+                    },
+                    "sorts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to sort results by."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    },
+                    "filterGroups": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FilterGroup"
+                        },
+                        "description": "Groups of filters used to narrow search results."
+                    }
+                },
+                "description": "Request payload for searching company records with filters, sorting, and pagination."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+                        "example": {
+                            "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "Invalid input (details will vary based on the error)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category",
+                        "example": "VALIDATION_ERROR"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "Represents an API error response, including a category, message, correlation ID, and optional context details."
+            },
+            "SimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The property name used as the unique identifier for the upsert."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the company record to upsert."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of company property names and their values."
+                    }
+                },
+                "description": "Input payload for upserting a single company record in a batch operation, including its ID and properties."
+            },
+            "BatchResponseSimplePublicObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant link names to their associated URIs."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "List of successfully processed company objects from the batch."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch operation response containing company results, processing status, timestamps, and any errors encountered."
+            },
+            "SimplePublicObjectInput": {
+                "required": [
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Key-value map of company property names and their values."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "city": "Cambridge",
+                        "name": "Biglytics",
+                        "phone": "(877) 929-0687",
+                        "state": "Massachusetts",
+                        "domain": "biglytics.net",
+                        "industry": "Technology"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "101"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input payload for creating or updating a company object with its properties."
+            },
+            "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next results page."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                        },
+                        "description": "Array of company objects returned in the current page."
+                    }
+                },
+                "description": "Paginated collection of company objects including their associations."
+            },
+            "AssociationSpec": {
+                "type": "object",
+                "properties": {
+                    "associationCategory": {
+                        "type": "string",
+                        "enum": [
+                            "HUBSPOT_DEFINED",
+                            "USER_DEFINED",
+                            "INTEGRATOR_DEFINED"
+                        ],
+                        "description": "The category that defines the association's origin or ownership."
+                    },
+                    "associationTypeId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Numeric identifier for the specific association type."
+                    }
+                },
+                "description": "Defines the category and type of an association between objects."
+            },
+            "PublicMergeInput": {
+                "required": [
+                    "objectIdToMerge",
+                    "primaryObjectId"
+                ],
+                "type": "object",
+                "properties": {
+                    "objectIdToMerge": {
+                        "type": "string",
+                        "description": "ID of the secondary company to be merged and removed."
+                    },
+                    "primaryObjectId": {
+                        "type": "string",
+                        "description": "ID of the primary company that will be retained after merge."
+                    }
+                },
+                "description": "Input payload specifying the two company records to merge."
+            },
+            "SimplePublicObjectWithAssociations": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/CollectionResponseAssociatedId"
+                        },
+                        "description": "Map of associated object collections keyed by association type."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the company record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the company record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the company record was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the company record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "description": "Key-value map of the company's current property values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp of the last update to the object."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "city": "Cambridge",
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "domain": "biglytics.net",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "industry": "Technology",
+                        "name": "Biglytics",
+                        "phone": "(877) 929-0687",
+                        "state": "Massachusetts"
+                    }
+                },
+                "description": "A company object including its properties, associations, and timestamps."
+            },
+            "Filter": {
+                "required": [
+                    "operator",
+                    "propertyName"
+                ],
+                "type": "object",
+                "properties": {
+                    "highValue": {
+                        "type": "string",
+                        "description": "Upper bound value for BETWEEN range filter operations."
+                    },
+                    "propertyName": {
+                        "type": "string",
+                        "description": "The company property name to evaluate in the filter."
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of values used with IN or NOT_IN filter operators."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The single value to compare against the specified property."
+                    },
+                    "operator": {
+                        "type": "string",
+                        "description": "Comparison operator that defines how the property is evaluated against the value.",
+                        "enum": [
+                            "EQ",
+                            "NEQ",
+                            "LT",
+                            "LTE",
+                            "GT",
+                            "GTE",
+                            "BETWEEN",
+                            "IN",
+                            "NOT_IN",
+                            "HAS_PROPERTY",
+                            "NOT_HAS_PROPERTY",
+                            "CONTAINS_TOKEN",
+                            "NOT_CONTAINS_TOKEN"
+                        ]
+                    }
+                },
+                "description": "Defines a filter condition used to query company records by property, operator, and value."
+            },
+            "BatchInputSimplePublicObjectBatchInput": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInput"
+                        },
+                        "description": "Array of company property update payloads to process in batch."
+                    }
+                },
+                "description": "Wraps a collection of company update inputs for batch processing."
+            },
+            "BatchInputSimplePublicObjectInputForCreate": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                        },
+                        "description": "Array of company creation payloads to process in batch."
+                    }
+                },
+                "description": "Wraps a collection of company creation inputs for batch processing."
+            },
+            "PreviousPage": {
+                "required": [
+                    "before"
+                ],
+                "type": "object",
+                "properties": {
+                    "before": {
+                        "type": "string",
+                        "description": "Cursor token representing the start of the previous page."
+                    },
+                    "link": {
+                        "type": "string",
+                        "description": "Navigable URL link to the previous page of results."
+                    }
+                },
+                "description": "Pagination cursor reference pointing to the previous page of results."
+            },
+            "SimplePublicUpsertObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "new",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the company record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the company record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp when the company record was archived."
+                    },
+                    "new": {
+                        "type": "boolean",
+                        "description": "Indicates whether the record was created new during the upsert."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the upserted company object."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of company property names to their values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "datetime",
+                        "description": "Timestamp indicating when the company record was last updated."
+                    }
+                },
+                "description": "Represents a company record returned after an upsert operation, indicating whether it was newly created."
+            },
+            "SimplePublicObjectBatchInput": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "example": "my_unique_property_name",
+                        "description": "Name of a unique property used to identify the company instead of the default record ID."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the company record to update."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of company property names to their updated values."
+                    }
+                },
+                "example": {
+                    "id": "1",
+                    "properties": {
+                        "city": "Cambridge",
+                        "name": "Biglytics",
+                        "phone": "(877) 929-0687",
+                        "state": "Massachusetts",
+                        "domain": "biglytics.net",
+                        "industry": "Technology"
+                    }
+                },
+                "description": "Input payload for updating a single company in a batch operation, including its identifier and property values."
+            },
+            "AssociatedId": {
+                "required": [
+                    "id",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the associated object."
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "Type label describing the nature of the association."
+                    }
+                },
+                "description": "Represents an associated object reference, defined by its ID and association type."
+            },
+            "NextPage": {
+                "required": [
+                    "after"
+                ],
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "example": "?after=NTI1Cg%3D%3D",
+                        "description": "Relative URL to fetch the next page of results."
+                    },
+                    "after": {
+                        "type": "string",
+                        "example": "NTI1Cg%3D%3D",
+                        "description": "Cursor token representing the position after the last returned result."
+                    }
+                },
+                "example": {
+                    "after": "NTI1Cg%3D%3D",
+                    "link": "?after=NTI1Cg%3D%3D"
+                },
+                "description": "Pagination cursor object used to retrieve the next page of results."
+            },
+            "SimplePublicObjectInputForCreate": {
+                "required": [
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicAssociationsForObject"
+                        },
+                        "description": "List of associations linking the new company to other CRM objects."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Key-value map of company property names to their initial values."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "city": "Cambridge",
+                        "name": "Biglytics",
+                        "phone": "(877) 929-0687",
+                        "state": "Massachusetts",
+                        "domain": "biglytics.net",
+                        "industry": "Technology"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "101"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input payload for creating a new company, including its properties and optional associations."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred.",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.goals.read": "Read goals",
+                            "tickets": "Read and write tickets",
+                            "crm.objects.custom.read": "View custom object records",
+                            "e-commerce": "e-commerce",
+                            "crm.objects.custom.write": "Change custom object records",
+                            "media_bridge.read": "Read media and media events"
+                        }
+                    }
+                }
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.companies.write": " ",
+                            "crm.objects.contacts.write": " ",
+                            "crm.objects.users.write": "Write User CRM objects",
+                            "crm.objects.commercepayments.read": "Read the COMMERCE_PAYMENT object.",
+                            "crm.objects.leads.write": "Modify lead objects",
+                            "crm.objects.subscriptions.read": "Read Commerce Subscriptions",
+                            "crm.objects.carts.read": "Read carts",
+                            "crm.objects.orders.write": "Write orders",
+                            "crm.objects.quotes.read": "Quotes",
+                            "crm.objects.services.read": "Read services",
+                            "crm.objects.orders.read": "Read Orders",
+                            "crm.objects.contacts.read": " ",
+                            "crm.objects.listings.read": "Read listings",
+                            "crm.objects.carts.write": "Write cart",
+                            "crm.objects.courses.write": "Write courses",
+                            "crm.objects.quotes.write": "Quotes",
+                            "crm.objects.users.read": "Read User CRM objects",
+                            "crm.objects.companies.read": " ",
+                            "crm.objects.appointments.read": "Read appointments",
+                            "crm.objects.partner-clients.write": "Modify Partner Client CRM objects",
+                            "crm.objects.leads.read": "Read lead objects",
+                            "crm.objects.appointments.write": "Write appointments",
+                            "crm.objects.services.write": "Write services",
+                            "crm.objects.line_items.read": "Line Items",
+                            "crm.objects.courses.read": "Read courses",
+                            "crm.objects.deals.read": " ",
+                            "crm.objects.invoices.read": "Read invoices objects",
+                            "crm.objects.partner-clients.read": "View Partner Client CRM objects",
+                            "crm.objects.deals.write": " ",
+                            "crm.objects.line_items.write": "Line Items",
+                            "crm.objects.listings.write": "Write listings"
+                        }
+                    }
+                }
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            },
+            "private_apps": {
+                "type": "apiKey",
+                "name": "private-app",
+                "in": "header",
+                "x-ballerina-name": "privateApp"
+            }
+        }
+    },
+    "x-hubspot-available-client-libraries": [
+        "PHP",
+        "Node",
+        "Ruby",
+        "Python"
+    ],
+    "x-hubspot-product-tier-requirements": {
+        "marketing": "FREE",
+        "sales": "FREE",
+        "service": "FREE",
+        "cms": "FREE"
+    },
+    "x-hubspot-documentation-banner": "NONE"
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,1707 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Companies",
+    "description" : "",
+    "version" : "v3",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "FREE",
+      "sales" : "FREE",
+      "service" : "FREE",
+      "cms" : "FREE"
+    },
+    "x-hubspot-documentation-banner" : "NONE",
+    "x-hubspot-api-use-case" : "When a new customer signs up on your website with their business email address, create a company record to represent the relationship between the customer and the company they work for. A sales rep can later use this company record for outreach to find other potential sales opportunities. ",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Companies Guide",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/crm/objects/companies"
+    } ],
+    "x-hubspot-introduction" : "Use the companies API to create and manage CRM records that represent the companies and organizations that interact with your business."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/crm/v3/objects/companies"
+  } ],
+  "tags" : [ {
+    "name" : "Batch"
+  }, {
+    "name" : "Basic"
+  }, {
+    "name" : "Merge"
+  }, {
+    "name" : "Search"
+  } ],
+  "paths" : {
+    "/batch/read" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Read a batch of companies by internal ID, or unique property values",
+        "operationId" : "post-/crm/v3/objects/companies/batch/read_read",
+        "parameters" : [ {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchReadInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.read" ]
+        } ]
+      }
+    },
+    "/{companyId}" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Read",
+        "description" : "Read an Object identified by `{companyId}`. `{companyId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+        "operationId" : "get-/crm/v3/objects/companies/{companyId}_getById",
+        "parameters" : [ {
+          "name" : "companyId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.read" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Archive",
+        "description" : "Move an Object identified by `{companyId}` to the recycling bin.",
+        "operationId" : "delete-/crm/v3/objects/companies/{companyId}_archive",
+        "parameters" : [ {
+          "name" : "companyId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Update",
+        "description" : "Perform a partial update of an Object identified by `{companyId}`or optionally a unique property value as specified by the `idProperty` query param. `{companyId}` refers to the internal object ID by default, and the `idProperty` query param refers to a property whose values are unique for the object. Provided property values will be overwritten. Read-only and non-existent properties will result in an error. Properties values can be cleared by passing an empty string.",
+        "operationId" : "patch-/crm/v3/objects/companies/{companyId}_update",
+        "parameters" : [ {
+          "name" : "companyId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/merge" : {
+      "post" : {
+        "tags" : [ "Merge" ],
+        "summary" : "Merge two companies with same type",
+        "operationId" : "post-/crm/v3/objects/companies/merge_merge",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicMergeInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/batch/archive" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Archive a batch of companies by ID",
+        "operationId" : "post-/crm/v3/objects/companies/batch/archive_archive",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/batch/create" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create a batch of companies",
+        "operationId" : "post-/crm/v3/objects/companies/batch/create_create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/batch/update" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Update a batch of companies by internal ID, or unique property values",
+        "operationId" : "post-/crm/v3/objects/companies/batch/update_update",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "List",
+        "description" : "Read a page of companies. Control what is returned via the `properties` query param.",
+        "operationId" : "get-/crm/v3/objects/companies_getPage",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The maximum number of results to display per page",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.read" ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Create",
+        "description" : "Create a company with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard companies is provided.",
+        "operationId" : "post-/crm/v3/objects/companies_create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/batch/upsert" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create or update a batch of companies by unique property values",
+        "description" : "Create or update records identified by a unique property value as specified by the `idProperty` query param. `idProperty` query param refers to a property whose values are unique for the object.",
+        "operationId" : "post-/crm/v3/objects/companies/batch/upsert_upsert",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.write" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.write" ]
+        } ]
+      }
+    },
+    "/search" : {
+      "post" : {
+        "tags" : [ "Search" ],
+        "operationId" : "post-/crm/v3/objects/companies/search_doSearch",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicObjectSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2" : [ "crm.objects.companies.read" ]
+        }, {
+          "private_apps" : [ "crm.objects.companies.read" ]
+        } ],
+        "x-hubspot-rate-limit-exemptions" : [ "ten-secondly" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "StandardError" : {
+        "required" : [ "category", "context", "errors", "links", "message", "status" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "object",
+            "properties" : { }
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CollectionResponseAssociatedId" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/Paging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociatedId"
+            }
+          }
+        }
+      },
+      "PublicAssociationsForObject" : {
+        "type" : "object",
+        "properties" : {
+          "types" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociationSpec"
+            }
+          },
+          "to" : {
+            "$ref" : "#/components/schemas/PublicObjectId"
+          }
+        }
+      },
+      "BatchResponseSimplePublicObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "FilterGroup" : {
+        "required" : [ "filters" ],
+        "type" : "object",
+        "properties" : {
+          "filters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Filter"
+            }
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "ForwardPaging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          }
+        }
+      },
+      "SimplePublicObjectId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchReadInputSimplePublicObjectId" : {
+        "required" : [ "inputs", "properties", "propertiesWithHistory" ],
+        "type" : "object",
+        "properties" : {
+          "propertiesWithHistory" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "idProperty" : {
+            "type" : "string"
+          },
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectId" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          }
+        }
+      },
+      "ValueWithTimestamp" : {
+        "required" : [ "sourceType", "timestamp", "value" ],
+        "type" : "object",
+        "properties" : {
+          "sourceId" : {
+            "type" : "string"
+          },
+          "sourceType" : {
+            "type" : "string"
+          },
+          "sourceLabel" : {
+            "type" : "string"
+          },
+          "updatedByUserId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "timestamp" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+            }
+          }
+        }
+      },
+      "CollectionResponseWithTotalSimplePublicObjectForwardPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          }
+        }
+      },
+      "SimplePublicObject" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "archived" : {
+            "type" : "boolean",
+            "example" : false
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "example" : "512"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        },
+        "example" : {
+          "id" : "512",
+          "properties" : {
+            "city" : "Cambridge",
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "domain" : "biglytics.net",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "industry" : "Technology",
+            "name" : "Biglytics",
+            "phone" : "(877) 929-0687",
+            "state" : "Massachusetts"
+          },
+          "createdAt" : "2019-10-30T03:30:17.883Z",
+          "updatedAt" : "2019-12-07T16:50:06.678Z",
+          "archived" : false
+        }
+      },
+      "PublicObjectId" : {
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Paging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          },
+          "prev" : {
+            "$ref" : "#/components/schemas/PreviousPage"
+          }
+        }
+      },
+      "PublicObjectSearchRequest" : {
+        "type" : "object",
+        "properties" : {
+          "query" : {
+            "type" : "string"
+          },
+          "limit" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "after" : {
+            "type" : "string"
+          },
+          "sorts" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "filterGroups" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/FilterGroup"
+            }
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+            "example" : {
+              "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "Invalid input (details will vary based on the error)"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category",
+            "example" : "VALIDATION_ERROR"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "SimplePublicObjectInput" : {
+        "required" : [ "properties" ],
+        "type" : "object",
+        "properties" : {
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "city" : "Cambridge",
+            "name" : "Biglytics",
+            "phone" : "(877) 929-0687",
+            "state" : "Massachusetts",
+            "domain" : "biglytics.net",
+            "industry" : "Technology"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "101"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      },
+      "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+            }
+          }
+        }
+      },
+      "AssociationSpec" : {
+        "type" : "object",
+        "properties" : {
+          "associationCategory" : {
+            "type" : "string",
+            "enum" : [ "HUBSPOT_DEFINED", "USER_DEFINED", "INTEGRATOR_DEFINED" ]
+          },
+          "associationTypeId" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "PublicMergeInput" : {
+        "required" : [ "objectIdToMerge", "primaryObjectId" ],
+        "type" : "object",
+        "properties" : {
+          "objectIdToMerge" : {
+            "type" : "string"
+          },
+          "primaryObjectId" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SimplePublicObjectWithAssociations" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/CollectionResponseAssociatedId"
+            }
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        },
+        "example" : {
+          "properties" : {
+            "city" : "Cambridge",
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "domain" : "biglytics.net",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "industry" : "Technology",
+            "name" : "Biglytics",
+            "phone" : "(877) 929-0687",
+            "state" : "Massachusetts"
+          }
+        }
+      },
+      "Filter" : {
+        "required" : [ "operator", "propertyName" ],
+        "type" : "object",
+        "properties" : {
+          "highValue" : {
+            "type" : "string"
+          },
+          "propertyName" : {
+            "type" : "string"
+          },
+          "values" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "operator" : {
+            "type" : "string",
+            "description" : "null",
+            "enum" : [ "EQ", "NEQ", "LT", "LTE", "GT", "GTE", "BETWEEN", "IN", "NOT_IN", "HAS_PROPERTY", "NOT_HAS_PROPERTY", "CONTAINS_TOKEN", "NOT_CONTAINS_TOKEN" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInput" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInput"
+            }
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectInputForCreate" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+            }
+          }
+        }
+      },
+      "PreviousPage" : {
+        "required" : [ "before" ],
+        "type" : "object",
+        "properties" : {
+          "before" : {
+            "type" : "string"
+          },
+          "link" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SimplePublicUpsertObject" : {
+        "required" : [ "createdAt", "id", "new", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          },
+          "new" : {
+            "type" : "boolean"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "datetime"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInput" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string",
+            "example" : "my_unique_property_name"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        },
+        "example" : {
+          "id" : "1",
+          "properties" : {
+            "city" : "Cambridge",
+            "name" : "Biglytics",
+            "phone" : "(877) 929-0687",
+            "state" : "Massachusetts",
+            "domain" : "biglytics.net",
+            "industry" : "Technology"
+          }
+        }
+      },
+      "AssociatedId" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "NextPage" : {
+        "required" : [ "after" ],
+        "type" : "object",
+        "properties" : {
+          "link" : {
+            "type" : "string",
+            "example" : "?after=NTI1Cg%3D%3D"
+          },
+          "after" : {
+            "type" : "string",
+            "example" : "NTI1Cg%3D%3D"
+          }
+        },
+        "example" : {
+          "after" : "NTI1Cg%3D%3D",
+          "link" : "?after=NTI1Cg%3D%3D"
+        }
+      },
+      "SimplePublicObjectInputForCreate" : {
+        "required" : [ "properties" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicAssociationsForObject"
+            }
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "city" : "Cambridge",
+            "name" : "Biglytics",
+            "phone" : "(877) 929-0687",
+            "state" : "Massachusetts",
+            "domain" : "biglytics.net",
+            "industry" : "Technology"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "101"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred.",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.goals.read" : "Read goals",
+              "tickets" : "Read and write tickets",
+              "crm.objects.custom.read" : "View custom object records",
+              "e-commerce" : "e-commerce",
+              "crm.objects.custom.write" : "Change custom object records",
+              "media_bridge.read" : "Read media and media events"
+            }
+          }
+        }
+      },
+      "oauth2" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.companies.write" : " ",
+              "crm.objects.contacts.write" : " ",
+              "crm.objects.users.write" : "Write User CRM objects",
+              "crm.objects.commercepayments.read" : "Read the COMMERCE_PAYMENT object.",
+              "crm.objects.leads.write" : "Modify lead objects",
+              "crm.objects.subscriptions.read" : "Read Commerce Subscriptions",
+              "crm.objects.carts.read" : "Read carts",
+              "crm.objects.orders.write" : "Write orders",
+              "crm.objects.quotes.read" : "Quotes",
+              "crm.objects.services.read" : "Read services",
+              "crm.objects.orders.read" : "Read Orders",
+              "crm.objects.contacts.read" : " ",
+              "crm.objects.listings.read" : "Read listings",
+              "crm.objects.carts.write" : "Write cart",
+              "crm.objects.courses.write" : "Write courses",
+              "crm.objects.quotes.write" : "Quotes",
+              "crm.objects.users.read" : "Read User CRM objects",
+              "crm.objects.companies.read" : " ",
+              "crm.objects.appointments.read" : "Read appointments",
+              "crm.objects.partner-clients.write" : "Modify Partner Client CRM objects",
+              "crm.objects.leads.read" : "Read lead objects",
+              "crm.objects.appointments.write" : "Write appointments",
+              "crm.objects.services.write" : "Write services",
+              "crm.objects.line_items.read" : "Line Items",
+              "crm.objects.courses.read" : "Read courses",
+              "crm.objects.deals.read" : " ",
+              "crm.objects.invoices.read" : "Read invoices objects",
+              "crm.objects.partner-clients.read" : "View Partner Client CRM objects",
+              "crm.objects.deals.write" : " ",
+              "crm.objects.line_items.write" : "Line Items",
+              "crm.objects.listings.write" : "Write listings"
+            }
+          }
+        }
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      },
+      "private_apps" : {
+        "type" : "apiKey",
+        "name" : "private-app",
+        "in" : "header",
+        "x-ballerina-name" : "privateApp"
+      }
+    }
+  },
+  "x-hubspot-available-client-libraries" : [ "PHP", "Node", "Ruby", "Python" ],
+  "x-hubspot-product-tier-requirements" : {
+    "marketing" : "FREE",
+    "sales" : "FREE",
+    "service" : "FREE",
+    "cms" : "FREE"
+  },
+  "x-hubspot-documentation-banner" : "NONE"
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,17 +1,17 @@
 _Author_: @DamsithAdikari
 _Created_: 2025/01/09 \
-_Updated_: 2025/01/10 \
+_Updated_: 2026/06/17 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification
 
 This document records the sanitation done on top of the official OpenAPI specification from Hubspot CRM API v3. The OpenAPI specification is obtained from the [Hubspot](https://developers.hubspot.com/docs/reference/api) OpenAPI Documentation. These changes are implemented to enhance the overall usability and readability of the generated client.
 
-
 1. **Change the `url` property of the `servers` object**:
     -  **Original**: `https://api.hubapi.com`
     -  **Sanitized**: `https://api.hubapi.com/crm/v3/objects/companies`
     -  **Reason**: The original URL is too generic and does not provide a clear indication of the API endpoint. The new one improves the consistency and usability of the APIs.
+
 2. **Update API Paths**:
     -  **Original**: Paths included reusable prefixes in each endpoint (e.g., `crm/v3/objects/companies`)
     -  **Updated**: Paths are modified to remove the reusable prefixes from the endpoints, as it is now included in the base URL. For example:

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_: @DamsithAdikari
 _Created_: 2025/01/09 \
-_Updated_: 2026/06/17 \\
+_Updated_: 2026/06/17 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification

--- a/examples/Company_create_count_delete/Ballerina.toml
+++ b/examples/Company_create_count_delete/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "wso2"
 name = "Company_create_count_delete"
 version = "0.1.0"
-distribution = "2201.10.3"
+distribution = "2201.12.2"
 
 [build-options]
 observabilityIncluded = true

--- a/examples/Company_create_count_delete/Dependencies.toml
+++ b/examples/Company_create_count_delete/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -116,7 +116,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -297,7 +297,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.obj.companies"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
@@ -308,7 +308,8 @@ dependencies = [
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
-	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"}
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"},
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies.mock.server"}
 ]
 
 [[package]]

--- a/examples/Company_create_count_delete/main.bal
+++ b/examples/Company_create_count_delete/main.bal
@@ -51,7 +51,7 @@ public function main() returns error? {
     };
 
     companies:BatchResponseSimplePublicObject|companies:BatchResponseSimplePublicObjectWithErrors|error createResponse =
-        hubSpotCrmCompanies->/companies/batch/create.post(createPayload);
+        hubSpotCrmCompanies->/batch/create.post(createPayload);
 
     string companyXId;
     string companyYId;
@@ -77,7 +77,7 @@ public function main() returns error? {
     };
 
     companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging|error getAllCompaniesResponse =
-        hubSpotCrmCompanies->/companies.get(queries = getQueries);
+        hubSpotCrmCompanies->/.get(queries = getQueries);
 
     if getAllCompaniesResponse is companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging {
         int initialCount = getAllCompaniesResponse.results.length();
@@ -88,7 +88,7 @@ public function main() returns error? {
     }
 
     // Step 3: Delete Company X
-    error? deleteResponse = hubSpotCrmCompanies->/companies/[companyXId].delete();
+    error? deleteResponse = hubSpotCrmCompanies->/[companyXId].delete();
 
     if deleteResponse is () {
         io:println("Deleted Company X with ID: ", companyXId);
@@ -98,7 +98,7 @@ public function main() returns error? {
     }
 
     // Step 4: Get All Companies and Print Count Again
-    getAllCompaniesResponse = hubSpotCrmCompanies->/companies.get(queries = getQueries);
+    getAllCompaniesResponse = hubSpotCrmCompanies->/.get(queries = getQueries);
 
     if getAllCompaniesResponse is companies:CollectionResponseSimplePublicObjectWithAssociationsForwardPaging {
         int finalCount = getAllCompaniesResponse.results.length();

--- a/examples/Company_update_merge/Ballerina.toml
+++ b/examples/Company_update_merge/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "wso2"
 name = "Company_update_merge"
 version = "0.1.0"
-distribution = "2201.10.3"
+distribution = "2201.12.2"
 
 [build-options]
 observabilityIncluded = true

--- a/examples/Company_update_merge/Dependencies.toml
+++ b/examples/Company_update_merge/Dependencies.toml
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -50,7 +50,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -70,7 +70,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.0"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -116,7 +116,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.15.0"
+version = "2.15.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -216,7 +216,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.0"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -243,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.10.0"
+version = "1.10.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"}
@@ -277,7 +277,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.0"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -297,7 +297,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "hubspot.crm.obj.companies"
-version = "2.0.0"
+version = "3.0.0"
 dependencies = [
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
@@ -308,7 +308,8 @@ dependencies = [
 	{org = "ballerinai", name = "observe"}
 ]
 modules = [
-	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"}
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies"},
+	{org = "ballerinax", packageName = "hubspot.crm.obj.companies", moduleName = "hubspot.crm.obj.companies.mock.server"}
 ]
 
 [[package]]

--- a/examples/Company_update_merge/main.bal
+++ b/examples/Company_update_merge/main.bal
@@ -40,7 +40,7 @@ public function main() returns error? {
         },
         associations: []
     };
-    companies:SimplePublicObject|error companyJResponse = hubSpotCrmCompanies->/companies.post(companyJPayload);
+    companies:SimplePublicObject|error companyJResponse = hubSpotCrmCompanies->/.post(companyJPayload);
 
     string companyJId;
     if companyJResponse is companies:SimplePublicObject {
@@ -59,7 +59,7 @@ public function main() returns error? {
         },
         associations: []
     };
-    companies:SimplePublicObject|error companyKResponse = hubSpotCrmCompanies->/companies.post(companyKPayload);
+    companies:SimplePublicObject|error companyKResponse = hubSpotCrmCompanies->/.post(companyKPayload);
 
     string companyKId;
     if companyKResponse is companies:SimplePublicObject {
@@ -77,7 +77,7 @@ public function main() returns error? {
             "domain": "updatedcompanyj.com"
         }
     };
-    companies:SimplePublicObject|error updateResponse = hubSpotCrmCompanies->/companies/[companyJId].patch(companyJUpdatePayload);
+    companies:SimplePublicObject|error updateResponse = hubSpotCrmCompanies->/[companyJId].patch(companyJUpdatePayload);
 
     if updateResponse is companies:SimplePublicObject {
         io:println("Updated Company J with new name and domain.");
@@ -91,7 +91,7 @@ public function main() returns error? {
         objectIdToMerge: companyJId,
         primaryObjectId: companyKId
     };
-    companies:SimplePublicObject|error mergeResponse = hubSpotCrmCompanies->/companies/merge.post(mergePayload);
+    companies:SimplePublicObject|error mergeResponse = hubSpotCrmCompanies->/merge.post(mergePayload);
 
     if mergeResponse is companies:SimplePublicObject {
         io:println("Merged Company J into Company K. Final Company ID: ", mergeResponse.id);

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=2.0.2-SNAPSHOT
+version=3.0.0-SNAPSHOT
 
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0


### PR DESCRIPTION
Improve operation summaries and add field descriptions

## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Improved the HubSpot CRM Companies connector documentation and regenerated artifacts to make the client easier to understand and use. Generated operation doc-comments in `ballerina/client.bal` were updated with clearer action-oriented summaries (including newly added/adjusted summaries to fit Ballerina doc-comment limits), and `ballerina/types.bal` was enriched with AI-generated field-level descriptions. The README quickstart “invoke” examples were also updated to match the current connector invocation style.

In addition, the PR refreshes the spec and sanitation metadata (`docs/spec/*.json`, `docs/spec/sanitations.md`) by regenerating the OpenAPI artifacts and updating the regeneration timestamp, adds the `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec files, and aligns the client implementation, mock service, and tests with the revised `/crm/v3/objects/companies` endpoint structure. Package and dependency versions were bumped (including `3.0.0`), and the changelog/Gradle properties were updated to reflect the release changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->